### PR TITLE
Update pimox.sh

### DIFF
--- a/pimox.sh
+++ b/pimox.sh
@@ -3,6 +3,5 @@
 apt install -y gnupg
 curl https://raw.githubusercontent.com/pimox/pimox7/master/KEY.gpg | apt-key add -
 echo "deb https://raw.githubusercontent.com/pimox/pimox7/master/ dev/" > /etc/apt/sources.list.d/pimox.list
-echo "deb http://deb.debian.org/debian bullseye contrib" > /etc/apt/sources.list.d/buster-contrib.list
 apt update
 apt install -y proxmox-ve


### PR DESCRIPTION
no need to force a bullseye version into buster-contrib.list file.

Maybe we could force buster to bullseye into original file in /etc/apt/sources.list with a
`sed -i 's/buster/bullseye/g' /etc/apt/sources.list{,.d/*.list}`

error on install
W: Target Packages (contrib/binary-arm64/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list.d/buster-contrib.list:1
W: Target Packages (contrib/binary-all/Packages) is configured multiple times in /etc/apt/sources.list:1 and /etc/apt/sources.list.d/buster-contrib.list:1