### PR TITLE
remove kernel-headers

### DIFF
--- a/RPiOS64-IA-Install.sh
+++ b/RPiOS64-IA-Install.sh
@@ -142,7 +142,7 @@ hostnamectl set-hostname $HOSTNAME
 printf "# PiMox7 Development Repo
 deb https://raw.githubusercontent.com/pimox/pimox7/master/ dev/ \n" > /etc/apt/sources.list.d/pimox.list
 curl https://raw.githubusercontent.com/pimox/pimox7/master/KEY.gpg |  apt-key add -
-apt update && apt upgrade -y && apt install -y raspberrypi-kernel-headers
+apt update && apt upgrade -y
 
 #### REMOVE DHCP, CLEAN UP ###############################################################################################################
 apt purge -y dhcpcd5


### PR DESCRIPTION
New version of Raspberry Pi OS is shipped with newer kernel, but version of raspberrypi-kernel-headers doesn't match with kernel. This couses error during ZFS installation. Actually it's not necessary to install any kernel headers, ZFS installation will pass even without it.  