### PR TITLE
Fix for dpkg error while installing pve-manager

### DIFF
--- a/RPiOS64-IA-Install.sh
+++ b/RPiOS64-IA-Install.sh
@@ -157,6 +157,11 @@ if [ "$(cat /boot/cmdline.txt | grep cgroup)" != "" ]
 fi
 
 #### INSTALL PIMOX7 AND REBOOT ###########################################################################################################
+
+#### Install pve-manager separately, and without recommended packages, to avoid packaging issue later.
+DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" pve-manager
+
+#### Continue with remaining packages
 DEBIAN_FRONTEND=noninteractive apt install -y -o Dpkg::Options::="--force-confdef" proxmox-ve
 
 #### RECONFIGURE NETWORK #### /etc/hosts REMOVE IPv6 #### /etc/network/interfaces.new CONFIGURE NETWORK TO CHANGE ON REBOOT ##############


### PR DESCRIPTION
While running the script, the following error will appear during the process:

proxmox-ve depends on pve-manager; however:
Package pve-manager is not configured yet.

This appears to be a combination of upstream issues and race conditions. Installing pve-manager by itself, prior to installing the proxmox-ve package, along with disabling optional dependencies, seems to fix this issue.

This pull request has the script install pve-manager early, before the other packages, so that it's already installed and configured by the time the remainder of the script performs the remaining functions.