### PR TITLE
Fix random MAC address on reboot or when a VM/LXC is stopped or started.

### DIFF
--- a/RPiOS64-IA-Install.sh
+++ b/RPiOS64-IA-Install.sh
@@ -82,6 +82,9 @@ if [ "$CORRECT" != "y" ]
   done
 fi
 
+#### MAC ################################################################################################################################
+MAC=$(cat /sys/class/net/eth0/address)
+
 #### AGREE TO CHANGES ###################################################################################################################
 printf "
 $YELLOW#########################################################################################
@@ -105,6 +108,7 @@ iface vmbr0 inet static
         bridge-ports eth0
         bridge-stp off
         bridge-fd 0
+        post-up ip link set vmbr0 address $MAC
 =========================================================================================
 THE HOSTNAMES IN : $YELLOW /etc/hosts $NORMAL WILL BE $RED OVERWRITTEN $NORMAL !!! WITH :
 127.0.0.1\tlocalhost
@@ -183,7 +187,8 @@ iface vmbr0 inet static
         gateway $GATEWAY
         bridge-ports eth0
         bridge-stp off
-        bridge-fd 0 \n" > /etc/network/interfaces.new
+        bridge-fd 0
+        post-up ip link set vmbr0 address $MAC \n" > /etc/network/interfaces.new
 
 #### CONFIGURE PIMOX7 BANNER #############################################################################################################
 cp /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js.auto.backup


### PR DESCRIPTION
I noticed that the raspberry's MAC changed on every reboot or when a container/vm is started. Nothing too problematic, but this requires other devices to update their ARP table more often than needed.

This PR sets the MAC of vmbr0 to the one of eth0 in the network config. This should fix the issue for new users. Old users need to append their `/etc/network/interfaces` with
```
        post-up ip link set vmbr0 address <MAC-address of eth0>
```

From my knowledge, it is required to set the MAC of vmbr0 to one of the bridged ports (in this case eth0). Else it gets randomly generated, and the set address is ignored.